### PR TITLE
Disable HTTPS redirection; enable forwarded headers

### DIFF
--- a/MangaShelf/Program.cs
+++ b/MangaShelf/Program.cs
@@ -100,7 +100,7 @@ public class Program
             app.UseHsts();
         }
 
-        app.UseHttpsRedirection();
+        // app.UseHttpsRedirection(); // Disabled - HTTPS not required
 
         app.UseStaticFiles();
         app.MapStaticAssets();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
         ASPNETCORE_ENVIRONMENT: Production
         ASPNETCORE_HTTP_PORTS: 8080
+        ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
     env_file:
       - .env
     volumes:
@@ -27,6 +28,7 @@ services:
     environment:
       DOTNET_ENVIRONMENT: Production
       ASPNETCORE_HTTP_PORTS: 8080
+      ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
     volumes:
       - images:/app/wwwroot/images:rw
     env_file:


### PR DESCRIPTION
Comment out HTTPS redirection in Program.cs to allow HTTP traffic, and set ASPNETCORE_FORWARDEDHEADERS_ENABLED=true in docker-compose.yml to support reverse proxy scenarios.