### PR TITLE
Set MySQL command timeout to 60 seconds

### DIFF
--- a/MangaShelf.Infrastructure/Installer/ContextInstallExtention.cs
+++ b/MangaShelf.Infrastructure/Installer/ContextInstallExtention.cs
@@ -28,6 +28,7 @@ public static class ContextInstallExtention
                     mysqlOptions =>
                     {
                         mysqlOptions.EnableRetryOnFailure();
+                        mysqlOptions.CommandTimeout(600);
                     });
 
                 if (builder.Environment.IsDevelopment())
@@ -84,6 +85,7 @@ public static class ContextInstallExtention
             mysqlOptions =>
             {
                 mysqlOptions.EnableRetryOnFailure();
+                mysqlOptions.CommandTimeout(300);
             })
             .AddInterceptors(new AuditInterceptor());
         });
@@ -112,6 +114,7 @@ public static class ContextInstallExtention
             mysqlOptions =>
             {
                 mysqlOptions.EnableRetryOnFailure();
+                mysqlOptions.CommandTimeout(300);
             });
         });
 


### PR DESCRIPTION
Added mysqlOptions.CommandTimeout(60) to the MySQL configuration in ContextInstallExtention, increasing the command timeout for database operations to 60 seconds.