### PR TITLE
Log DB connection strings and update connection settings

### DIFF
--- a/MangaShelf.Infrastructure/Installer/ContextInstallExtention.cs
+++ b/MangaShelf.Infrastructure/Installer/ContextInstallExtention.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 
 namespace MangaShelf.Infrastructure.Installer;
@@ -18,6 +19,11 @@ public static class ContextInstallExtention
     public static IHostApplicationBuilder RegisterIdentityContextAndServices(this IHostApplicationBuilder builder)
     {
         var connectionString = builder.Configuration.GetConnectionString("AccountsDb") ?? throw new InvalidOperationException("Connection string 'AccountsDb' not found.");
+        var logger = LoggerFactory.Create(b =>
+        {
+            b.AddConsole();
+        }).CreateLogger(nameof(RegisterIdentityContextAndServices));
+        logger.LogWarning(connectionString);
 
         var accontDbVersion = ServerVersion.Parse("8.0");
         builder.Services.AddDbContext<MangaIdentityDbContext>(
@@ -28,7 +34,6 @@ public static class ContextInstallExtention
                     mysqlOptions =>
                     {
                         mysqlOptions.EnableRetryOnFailure();
-                        mysqlOptions.CommandTimeout(600);
                     });
 
                 if (builder.Environment.IsDevelopment())
@@ -71,6 +76,11 @@ public static class ContextInstallExtention
     private static IHostApplicationBuilder RegisterShelfContextAndServices(IHostApplicationBuilder builder)
     {
         var connectionString = builder.Configuration.GetConnectionString("MangaDb") ?? throw new InvalidOperationException("Connection string 'MangaDb' not found.");
+        var logger = LoggerFactory.Create(b =>
+        {
+            b.AddConsole();
+        }).CreateLogger(nameof(RegisterShelfContextAndServices));
+        logger.LogWarning(connectionString);
 
         var accontDbVersion = ServerVersion.Parse("8.0");
         var sqlConfiguration = new Action<DbContextOptionsBuilder>(options =>
@@ -85,7 +95,6 @@ public static class ContextInstallExtention
             mysqlOptions =>
             {
                 mysqlOptions.EnableRetryOnFailure();
-                mysqlOptions.CommandTimeout(300);
             })
             .AddInterceptors(new AuditInterceptor());
         });
@@ -101,6 +110,12 @@ public static class ContextInstallExtention
     {
         var connectionString = builder.Configuration.GetConnectionString("SystemDb") ?? throw new InvalidOperationException("Connection string 'SystemDb' not found.");
 
+        var logger = LoggerFactory.Create(b =>
+        {
+            b.AddConsole();
+        }).CreateLogger(nameof(RegisterSystemContextAndServices));
+        logger.LogWarning(connectionString);
+
         var accontDbVersion = ServerVersion.Parse("8.0");
         var sqlConfiguration = new Action<DbContextOptionsBuilder>(options =>
         {
@@ -111,11 +126,10 @@ public static class ContextInstallExtention
 
             options
             .UseMySql(connectionString, accontDbVersion,
-            mysqlOptions =>
-            {
-                mysqlOptions.EnableRetryOnFailure();
-                mysqlOptions.CommandTimeout(300);
-            });
+                mysqlOptions =>
+                {
+                    mysqlOptions.EnableRetryOnFailure();
+                });
         });
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       - manga-network
     environment:
       DOTNET_ENVIRONMENT: Production
+      ConnectionStrings__MangaDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${MANGA_DATABASE}"
+      ConnectionStrings__AccountsDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${ACCOUNTS_DATABASE}"
+      ConnectionStrings__SystemDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${SYSTEM_DATABASE}"
     env_file:
       - .env
     restart: on-failure
@@ -34,6 +37,9 @@ services:
         ASPNETCORE_ENVIRONMENT: Production
         ASPNETCORE_HTTP_PORTS: 8080
         ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
+        ConnectionStrings__MangaDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${MANGA_DATABASE}"
+        ConnectionStrings__AccountsDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${ACCOUNTS_DATABASE}"
+        ConnectionStrings__SystemDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${SYSTEM_DATABASE}"
     env_file:
       - .env
     volumes:
@@ -53,6 +59,9 @@ services:
       DOTNET_ENVIRONMENT: Production
       ASPNETCORE_HTTP_PORTS: 8080
       ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
+      ConnectionStrings__MangaDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${MANGA_DATABASE}"
+      ConnectionStrings__AccountsDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${ACCOUNTS_DATABASE}"
+      ConnectionStrings__SystemDb: "server=${MANGA_HOST};user id=${MANGA_USER};password=${MANGA_PASSWORD};database=${SYSTEM_DATABASE}"
     volumes:
       - images:/app/wwwroot/images:rw
     env_file:


### PR DESCRIPTION
Add logging of DB connection strings in context installers using ILogger. Remove MySQL command timeout settings from shelf and system contexts. Inject DB connection strings via environment variables in docker-compose.yml for migration, API, and web services.